### PR TITLE
deleted class small

### DIFF
--- a/modules/ps_contactinfo/nav.tpl
+++ b/modules/ps_contactinfo/nav.tpl
@@ -23,7 +23,7 @@
  * International Registered Trademark & Property of PrestaShop SA
  *}
 <div id="_desktop_contact_link">
-  <div id="contact-link" class="small">
+  <div id="contact-link">
     {if $contact_infos.phone}
       {* [1][/1] is for a HTML tag. *}
       {l


### PR DESCRIPTION
Why class="small" is here !? I think it's much better if the right side and left side are the same. Same size of typo.