### PR TITLE
Fix display of discount flags

### DIFF
--- a/templates/catalog/_partials/miniatures/product.tpl
+++ b/templates/catalog/_partials/miniatures/product.tpl
@@ -105,10 +105,12 @@
                     {foreach from=$product.flags item=flag}
                         <li class="product-flag {$flag.type}">{$flag.label}</li>
                     {/foreach}
-                    {if $product.discount_type === 'percentage'}
-                        <li class="product-flag discount-percentage discount-product">{$product.discount_percentage}</li>
-                    {elseif $product.discount_type === 'amount'}
-                        <li class="product-flag discount-amount discount-product">{$product.discount_amount_to_display}</li>
+                    {if $product.has_discount}
+                        {if $product.discount_type === 'percentage'}
+                            <li class="product-flag discount-percentage discount-product">{$product.discount_percentage}</li>
+                        {elseif $product.discount_type === 'amount'}
+                            <li class="product-flag discount-amount discount-product">{$product.discount_amount_to_display}</li>
+                        {/if}
                     {/if}
                 </ul>
             {/block}


### PR DESCRIPTION
There was a missing condition and it was showing -"0 CZK" discount, if you used specific prices.

Reported here https://github.com/PrestaShop/PrestaShop/issues/16684