### PR TITLE
Fix contrast of badge text with background

### DIFF
--- a/templates/customer/order-detail.tpl
+++ b/templates/customer/order-detail.tpl
@@ -93,7 +93,7 @@
             <tr>
               <td>{$state.history_date}</td>
               <td>
-                <span class="badge badge-pill {$state.contrast}" style="background-color:{$state.color}">
+                <span class="badge badge-pill" style="color:#fff;background-color:{$state.color}">
                   {$state.ostate_name}
                 </span>
               </td>
@@ -106,7 +106,7 @@
           <div class="history-line">
             <div class="date">{$state.history_date}</div>
             <div class="state">
-              <span class="badge badge-pill {$state.contrast}" style="background-color:{$state.color}">
+              <span class="badge badge-pill" style="color:#fff;background-color:{$state.color}">
                 {$state.ostate_name}
               </span>
             </div>


### PR DESCRIPTION
Improve the contrast as you can see

> Before
![badge1](https://user-images.githubusercontent.com/11728231/72890814-112c2480-3d13-11ea-9978-ba93286305e1.png)

> After
![badge2](https://user-images.githubusercontent.com/11728231/72890865-2bfe9900-3d13-11ea-911d-243933e722bf.png)
