### PR TITLE
Rework of .custom-file translations

### DIFF
--- a/modules/contactform/views/templates/widget/contactform.tpl
+++ b/modules/contactform/views/templates/widget/contactform.tpl
@@ -83,16 +83,9 @@
                 </label>
                   <div class="custom-file">
                     <input name="fileUpload" type="file" class="custom-file-input" id="fileUpload">
-                    <label class="custom-file-label" for="fileUpload"><span class="sr-only">{l s='Choose file' d='Shop.Theme.Actions'}</span></label>
+                    <label class="custom-file-label" for="fileUpload" data-browse="{l s='Choose file' d='Shop.Theme.Actions'}"><span class="sr-only">{l s='Choose file' d='Shop.Theme.Actions'}</span></label>
                   </div>
               </div>
-            {literal}
-              <style>
-                    .custom-file-label::after{
-                    content:"{/literal}{l s='Choose file' d='Shop.Theme.Actions'}"{literal}
-                    }
-              </style>
-            {/literal}
             {/if}
 
           <div class="form-group">

--- a/templates/_partials/footer.tpl
+++ b/templates/_partials/footer.tpl
@@ -54,13 +54,3 @@
     </div>
   </div>
 </div>
-
-
-
-{literal}
-<style>
-  .custom-file-label::after{
-    content:"{/literal}{l s='Choose file' d='Shop.Theme.Actions'}"{literal}
-  }
-</style>
-{/literal}

--- a/templates/_partials/form-fields.tpl
+++ b/templates/_partials/form-fields.tpl
@@ -187,7 +187,7 @@
             {elseif $field.type === 'file'}
                 <div class="custom-file">
                     <input name="{$field.name}" type="file" class="custom-file-input{if !empty($field.errors)} is-invalid{/if}" id="f-{$field.name}_{$uniqId}"{if $field.required} required{/if}>
-                    <label class="custom-file-label" for="f-{$field.name}_{$uniqId}">{l s='Choose file' d='Shop.Theme.Actions'}</label>
+                    <label class="custom-file-label" for="f-{$field.name}_{$uniqId}" data-browse="{l s='Choose file' d='Shop.Theme.Actions'}">{l s='Choose file' d='Shop.Theme.Actions'}</label>
                 </div>
             {else}
 

--- a/templates/catalog/_partials/product-customization.tpl
+++ b/templates/catalog/_partials/product-customization.tpl
@@ -59,7 +59,7 @@
                                 <input class="custom-file-input" {if $field.required} required {/if} type="file"
                                        name="{$field.input_name}" id="field-{$field.id_customization_field}">
                                 <label class="custom-file-label"
-                                       for="field-{$field.id_customization_field}">{l s='Choose file' d='Shop.Theme.Actions'}</label>
+                                       for="field-{$field.id_customization_field}" data-browse="{l s='Choose file' d='Shop.Theme.Actions'}">{l s='Choose file' d='Shop.Theme.Actions'}</label>
                                 <div class="invalid-feedback js-invalid-feedback-browser"></div>
 
                             </div>


### PR DESCRIPTION
According to [Bootstrap documentation](https://getbootstrap.com/docs/4.3/components/forms/#translating-or-customizing-the-strings-with-html) about `.custom-file` form element, we can now translate the "Browse" text in HTML with `data-browse` attribute. This PR add this attribute on every `.custom-file` elements and remove useless inline `<style>` tags.