### PR TITLE
Rename .full-bleed utility class

### DIFF
--- a/_dev/css/components/utilities.scss
+++ b/_dev/css/components/utilities.scss
@@ -29,7 +29,7 @@ img[data-lazy] {
   justify-content: space-between;
 }
 
-.full-bleed {
+.full-width {
   width: 100vw;
   margin-left: 50%;
   transform: translateX(-50%);


### PR DESCRIPTION
I think we need to use `.full-width` utility instead of `.full-bleed`.
This class name is more relevant.