### PR TITLE
Clean custom.js file

### DIFF
--- a/assets/js/custom.js
+++ b/assets/js/custom.js
@@ -1,23 +1,3 @@
-//Slick orientation trigger
-$(window).on("orientationchange",function(){
-    $('[data-slick]').slick('reinit');
-});
-$('.products-slick').on('init reInit', function (e) {
-    // console.log(e);
-    var _el = e.target;
-
-    jbResizeSlider(_el);
-});
-
-//since multiple events can trigger a slider adjustment, we will control that adjustment here
-function jbResizeSlider(_el){
-    $('.card-product',_el).height('auto');
-
-    var slickTrack = $('.slick-track',_el);
-    var slickTrackHeight = slickTrack.height();
-
-    $('.card-product',_el).css('height', slickTrackHeight + 'px');
-}
 /*
  * Custom code goes here.
  * A template should always ship with an empty custom.js


### PR DESCRIPTION
The `custom.js` file must always be empty.
Moreover, this code seems useless and causes Slick issues on orientation change.